### PR TITLE
Exclude Smart Switch from modular chassis operations/checks

### DIFF
--- a/fwutil/lib.py
+++ b/fwutil/lib.py
@@ -196,6 +196,9 @@ class PlatformDataProvider(object):
 
     def get_chassis(self):
         return self.__chassis
+    
+    def is_smart_switch(self):
+        return self.__chassis.is_smartswitch()
 
     def is_modular_chassis(self):
         return len(self.module_component_map) > 0
@@ -535,8 +538,8 @@ class ComponentUpdateProvider(PlatformDataProvider):
             os.mkdir(FIRMWARE_AU_STATUS_DIR)
 
         self.__root_path = root_path
-
-        self.__pcp = PlatformComponentsParser(self.is_modular_chassis())
+        is_modular_chassis = self.is_modular_chassis() and not self.is_smart_switch()
+        self.__pcp = PlatformComponentsParser(is_modular_chassis)
         self.__pcp.parse_platform_components(root_path)
 
         self.__validate_platform_schema(self.__pcp)
@@ -546,6 +549,9 @@ class ComponentUpdateProvider(PlatformDataProvider):
 
     def __validate_component_map(self, section, pdp_map, pcp_map):
         diff_keys = self.__diff_keys(list(pdp_map.keys()), list(pcp_map.keys()))
+
+        if diff_keys and section == self.SECTION_MODULE and self.is_smart_switch():
+            return
 
         if diff_keys:
             raise RuntimeError(


### PR DESCRIPTION

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

Avoid any modular chassis operations on smart-switch

#### How I did it

Checked if chassis is smart switch before performing modular chassis operations/checks

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

